### PR TITLE
Replaced dls-controls with DiamondLightSource

### DIFF
--- a/.gitremotes
+++ b/.gitremotes
@@ -1,1 +1,1 @@
-github git@github.com:dls-controls/terminalServer.git
+github git@github.com:DiamondLightSource/terminalServer.git


### PR DESCRIPTION
Repository was automatically transferred from `dls-controls/terminalServer` using https://gitlab.diamond.ac.uk/github/github-scripts